### PR TITLE
Fix vram access checking on .pocket builds

### DIFF
--- a/src/field.asm
+++ b/src/field.asm
@@ -103,8 +103,8 @@ BlitField::
     REPT 7
         ; Wait until start of drawing, then insert nops.
 :       ldh a, [rSTAT]
-        and a, 3
-        cp a, 3
+        and a, STATF_LCD
+        cp a, STATF_LCD
         jr nz, :-
         REPT 40
             nop
@@ -160,8 +160,8 @@ BigBlitField::
     REPT 7
         ; Wait until start of drawing, then insert nops.
 :       ldh a, [rSTAT]
-        and a, 3
-        cp a, 3
+        and a, STATF_LCD
+        cp a, STATF_LCD
         jr nz, :-
         REPT 40
             nop


### PR DESCRIPTION
Use platform dependent constants so that video mode checks work on .pocket builds too.
DMG mode in particular was getting vram access exceptions in Emulicious when running the .pocket build + system type forced to GB.